### PR TITLE
Extra features and bux fix

### DIFF
--- a/lib/googleImageSearch.py
+++ b/lib/googleImageSearch.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3.8
 
-import requests
 import io
 import os
 import re
-from urllib.parse import quote
 import sys
 import time
 import random
-import requests_random_user_agent
-from PIL import Image
 import hashlib
+import requests
+from PIL import Image
+from urllib.parse import quote
+import requests_random_user_agent
 
 class GetThem:
-    def __init__( self, log ):
+    def __init__( self, log, pause, b_pause ):
         self.log = log
         self.gooBan = True
 
@@ -21,6 +21,9 @@ class GetThem:
         self.ghost_pic = os.path.join( os.path.abspath( sys.argv[0].replace( 'main.py' , '' ) ), 'lib', 'ghost.png' )
         if not os.path.isdir( self.pic_dir ):
             os.makedirs( self.pic_dir )
+
+        self.pause = pause
+        self.b_pause = b_pause
 
     def download_img( self, url ):
         self.log.info( f'Trying to download {url}' )
@@ -42,12 +45,19 @@ class GetThem:
         except Exception as e:
             self.log.error( f'ERROR - Could not save {url} - {e}' )
 
-
     def waitRand( self ):
         ttt = random.randint(1000000000,6000000000)/10000000000
         self.log.info( f'Sleeping --> {ttt} seconds' )
         time.sleep( ttt )
 
+    def beeeeep( self ):
+        duration = 0.1
+        for freq in range(200,400,50):
+            os.system('play -nq -t alsa synth {} sine {}'.format(duration, freq))
+        time.sleep(.2)
+        os.system('play -nq -t alsa synth {} sine {}'.format(duration, 400))
+        time.sleep(.1)
+        os.system('play -nq -t alsa synth {} sine {}'.format(duration, 400))
 
     def getThem( self, img_link, job_title, location ):
 
@@ -101,8 +111,31 @@ class GetThem:
                 name = ' '.join( link.split( '/' )[-1].split('-')[:-1] )
                 self.log.findings( f'Found potential matching account --> {name}' )
             elif BAN in search_results.text:
-                self.log.warning( 'GOOGLE trowed a reCAPTCHA.' )
-                self.gooBan = False
+                self.log.error( 'GOOGLE trowed a reCAPTCHA.' )
+
+                if self.pause or self.b_pause:
+                    if self.b_pause:
+                        self.beeeeep()
+                    self.log.warning( 'System paused, do what you need to do.. ..' )
+
+                    right = False
+                    while not right:
+                        self.log.warning( 'Do you want to retry the same query? [Yy/Nn]' )
+                        answ = input()
+
+                        if answ.isalpha():
+                            if answ.lower() == 'y':
+                                self.getThem( img_link, job_title, location )
+                            elif answ.lower() == 'n':
+                                right = True
+                            else:
+                                self.log.error( 'That was not an answer. Let\'s try again.' )
+                        else:
+                            self.log.error( 'That was not an answer. Let\'s try again.' )
+
+                else:
+                    self.gooBan = False
+
             elif nothing in search_results.text:
                 self.log.warning( 'No results for this query.' )
 

--- a/lib/googleImageSearch.py
+++ b/lib/googleImageSearch.py
@@ -50,15 +50,6 @@ class GetThem:
         self.log.info( f'Sleeping --> {ttt} seconds' )
         time.sleep( ttt )
 
-    def beeeeep( self ):
-        duration = 0.1
-        for freq in range(200,400,50):
-            os.system('play -nq -t alsa synth {} sine {}'.format(duration, freq))
-        time.sleep(.2)
-        os.system('play -nq -t alsa synth {} sine {}'.format(duration, 400))
-        time.sleep(.1)
-        os.system('play -nq -t alsa synth {} sine {}'.format(duration, 400))
-
     def getThem( self, img_link, job_title, location ):
 
         name = None
@@ -111,27 +102,9 @@ class GetThem:
                 name = ' '.join( link.split( '/' )[-1].split('-')[:-1] )
                 self.log.findings( f'Found potential matching account --> {name}' )
             elif BAN in search_results.text:
-                self.log.error( 'GOOGLE trowed a reCAPTCHA.' )
-
+                self.log.error( 'GOOGLE threw a reCAPTCHA.' )
                 if self.pause or self.b_pause:
-                    if self.b_pause:
-                        self.beeeeep()
-                    self.log.warning( 'System paused, do what you need to do.. ..' )
-
-                    right = False
-                    while not right:
-                        self.log.warning( 'Do you want to retry the same query? [Yy/Nn]' )
-                        answ = input()
-
-                        if answ.isalpha():
-                            if answ.lower() == 'y':
-                                self.getThem( img_link, job_title, location )
-                            elif answ.lower() == 'n':
-                                right = True
-                            else:
-                                self.log.error( 'That was not an answer. Let\'s try again.' )
-                        else:
-                            self.log.error( 'That was not an answer. Let\'s try again.' )
+                    return None, None, True
 
                 else:
                     self.gooBan = False
@@ -147,6 +120,6 @@ class GetThem:
             self.log.error( '''Google doesn't like us anymore''' )
 
         if name and link:
-            return name, link
+            return name, link, False
         else:
-            return None, None
+            return None, None, False

--- a/lib/linkedinCompanyScraper.py
+++ b/lib/linkedinCompanyScraper.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3.8
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options 
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from lib import googleImageSearch
 import time
 import random
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options 
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+from lib import googleImageSearch
 
 class LinkedIn :
-    def __init__( self, log, stash ):
+    def __init__( self, log, stash, company_url, temp_file, res, pause, beeppause ):
         self.chrome_options = Options()
         self.chrome_options.add_argument("--headless")
         self.chrome_options.add_argument("--window-size=1920,1080")
@@ -23,10 +24,18 @@ class LinkedIn :
         #                                upload_throughput=50 * 1024 )  # maximal throughput
 
         self.log = log
-        self.goog = googleImageSearch.GetThem( log )
+        self.goog = googleImageSearch.GetThem( log, pause, beeppause )
         self.stash = stash
         # self.t = concurrent.futures.ThreadPoolExecutor(max_workers=100)
         # self.threads = []
+
+        self.c_link = company_url
+        self.t_file = temp_file
+        self.resume = res
+
+        if res:
+            with open( remp_file , 'r' ) as tmp:
+                tmp.readline()
 
     def __sleep_rand( self ):
         time.sleep( random.randrange(1000,2000) * 0.001 )
@@ -71,7 +80,7 @@ class LinkedIn :
                 pic_lnk = pic_lnk if pic_lnk else 'NA'
                 sqlq = 'INSERT INTO hidden_employees( comp_link, position, prof_pic ) VALUES(?, ?, ?)'
                 sqlv = ( self.c_link, job_title, pic_lnk )
-                self.log.info( f'Impossible to find user. Details saved anyway.' )
+                self.log.warning( f'Impossible to find user. Details saved anyway.' )
                 self.stash.sql_execcc( sqlq, sqlv )
 
         except Exception as e:
@@ -112,8 +121,7 @@ class LinkedIn :
                 self.log.warning( 'No user info' )
                 infos = None
 
-    def scrapeThoseEmployeez( self, email, password, company_url ):
-        self.c_link = company_url
+    def scrapeThoseEmployeez( self, email, password ):
         self.login( email , password )
 
         # marks xpath

--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ def main() :
     
     parser.add_argument( '-B', '--beeep_n_pause_captcha', action='store_true', help='Pause when LazyOSINT hits reCAPTCHA and Beep!\n')
     parser.add_argument( '-b', '--pause_captcha', action='store_true', help='Pause when LazyOSINT hits reCAPTCHA, no beep.\n')
+    parser.add_argument( '-S', '--skip_google', action='store_true', help='Skip Google search for hidden profiles.\n')
     parser.add_argument( '-r', '--resume_linkedin', action='store_true', help='Resume an interrupted LinkedIn scraper - Need to specify the exact same LinkedIn url (-u).\n')
 
     args = parser.parse_args()
@@ -129,10 +130,10 @@ def main() :
         if not password:
             password = getpass.getpass( prompt='Password: ' )
 
-        lnkd = LinkedIn( log, stash, linkedin_url, temp_file, res=args.resume_linkedin, pause=args.pause_captcha, beeppause=args.beeep_n_pause_captcha )
-        
-        ### linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password, linkedin_url ) ]
+        lnkd = LinkedIn( log, stash, linkedin_url, temp_file, args.resume_linkedin, args.pause_captcha, args.beeep_n_pause_captcha, args.skip_google )
+        # linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password ) ]
         lnkd.scrapeThoseEmployeez( email, password )
+        exit(0)
 
     if domain :
         doms = whoisNstuff( log, stash )
@@ -148,7 +149,6 @@ def main() :
 
     if linkedin_url :
         lin = [ x.result() for x in concurrent.futures.as_completed( linkedinT ) ]
-
 
     # if report_name:
     #     rep = Reporting( db_file, report_name, log )

--- a/main.py
+++ b/main.py
@@ -131,9 +131,8 @@ def main() :
             password = getpass.getpass( prompt='Password: ' )
 
         lnkd = LinkedIn( log, stash, linkedin_url, temp_file, args.resume_linkedin, args.pause_captcha, args.beeep_n_pause_captcha, args.skip_google )
-        # linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password ) ]
-        lnkd.scrapeThoseEmployeez( email, password )
-        exit(0)
+        linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password ) ]
+        # lnkd.scrapeThoseEmployeez( email, password )
 
     if domain :
         doms = whoisNstuff( log, stash )

--- a/main.py
+++ b/main.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python3.8
 
-import sys
 import os
 import re
-import getpass
+import sys
+import shutil
 import string
+import getpass
+import hashlib
 import argparse
 import configparser
-import shutil
 import concurrent.futures
 from urllib.parse import quote
 from platform import python_version
 
-from lib.logger import Stash, Logger, Fuffa
 from lib.domains import whoisNstuff
+from lib.logger import Stash, Logger, Fuffa
 from lib.linkedinCompanyScraper import LinkedIn
 
 def fPath( name , t ):
@@ -22,10 +23,10 @@ def fPath( name , t ):
         os.makedirs( out_fold )
 
     if name:
-        valid_chars = f'_{string.ascii_letters}{string.digits}'
+        valid_chars = f'._{string.ascii_letters}{string.digits}'
         myName = ''.join(c for c in name if c in valid_chars)
         fp = os.path.join( out_fold , myName )
-        return fp + '.docx' if t == 'doc' else fp + '.db' if t == 'db' else fp + '.lazyLog'
+        return fp if t == 'tmp' else fp + '.db' if t == 'db' else fp + '.lazyLog'
     else:
         return None
 
@@ -48,6 +49,11 @@ def main() :
     parser.add_argument( '-p', '--password', help='Linkedin password. If omitted and arg -u is given, you will be prompted fro a password.\n')
     parser.add_argument( '-u', '--linkedin_url', help='Target company\'s Linkedin Profile. Example --> https://www.linkedin.com/company/niceCompanyName/\n')
     parser.add_argument( '-N', '--no_resolv', action='store_true', help='Do NOT resolv subdomains nor check for open ports.\n')
+    
+    parser.add_argument( '-B', '--beeep_n_pause_captcha', action='store_true', help='Pause when LazyOSINT hits reCAPTCHA and Beep!\n')
+    parser.add_argument( '-b', '--pause_captcha', action='store_true', help='Pause when LazyOSINT hits reCAPTCHA, no beep.\n')
+    parser.add_argument( '-r', '--resume_linkedin', action='store_true', help='Resume an interrupted LinkedIn scraper - Need to specify the exact same LinkedIn url (-u).\n')
+
     args = parser.parse_args()
 
     # report_name = fPath( args.report_name, 'doc' )
@@ -78,6 +84,8 @@ def main() :
     if linkedin_url:
         stash.db_init( linkedin_url )
         urlecoded = quote( linkedin_url , safe=':/' )
+        temp_file = fPath( f'.{str(hashlib.sha1( linkedin_url.encode() ).hexdigest())}' , 'tmp' )
+
         if 'https://www.linkedin.com/' in urlecoded :
             linkedin_url = urlecoded
         else :
@@ -121,9 +129,10 @@ def main() :
         if not password:
             password = getpass.getpass( prompt='Password: ' )
 
-        lnkd = LinkedIn( log, stash )
-        linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password, linkedin_url ) ]
-        # lnkd.scrapeThoseEmployeez( email, password, linkedin_url )
+        lnkd = LinkedIn( log, stash, linkedin_url, temp_file, res=args.resume_linkedin, pause=args.pause_captcha, beeppause=args.beeep_n_pause_captcha )
+        
+        ### linkedinT = [ t.submit( lnkd.scrapeThoseEmployeez, email, password, linkedin_url ) ]
+        lnkd.scrapeThoseEmployeez( email, password )
 
     if domain :
         doms = whoisNstuff( log, stash )


### PR DESCRIPTION
LazyOSINT, while scraping LinkedIn, can now be brutally interrupted ( `^C` ) at any time and then resumed by using the flag `-r`; the file containing the information necessary to resume the scan on the same page are NOT saved in the system `/tmp` so you can shut down your pc and carry on with the scan whenever you feel like. Note that when using the resume function, you need to specify the exact same LinkedIn url in the exact same format ( with `-u` ) otherwise it will not find the file.

The flag `-S` can be used if you want to skip the Google search for hidden profiles.
The flag `-b` pauses the scan whenever Google hits a reCaptcha (a bit messy to resume if doing a full scan) while the flag `-B` also make a sound before pausing. If `-b` or `-B` is used together with `-d`, it is very likely that the screen log informing the user about the LinkedIn scraper pausing at the reCaptcha could go out of screen, in that case you just need to press enter to get it printed again or just answer the y/n question once you get use to. I will probably find better way to do it one day.

